### PR TITLE
tests: drivers: watchdog: wdt_instances: fix platform name

### DIFF
--- a/tests/drivers/watchdog/wdt_instances/testcase.yaml
+++ b/tests/drivers/watchdog/wdt_instances/testcase.yaml
@@ -14,7 +14,7 @@ tests:
       - nrf54h20dk/nrf54h20/cpuflpr
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54lm20dk/nrf54lm20a/cpuapp
-      - nrf54ls05pdkk@0.0.0/nrf54ls05b/cpuapp
+      - nrf54ls05pdk@0.0.0/nrf54ls05b/cpuapp
       - nrf54ls05pdk/nrf54ls05b/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp
       - nrf54lv10dk@0.0.0/nrf54lv10a/cpuapp
@@ -23,5 +23,5 @@ tests:
       - nrf54h20dk/nrf54h20/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54lm20dk/nrf54lm20a/cpuapp
-      - nrf54ls05pdkk@0.0.0/nrf54ls05b/cpuapp
+      - nrf54ls05pdk@0.0.0/nrf54ls05b/cpuapp
       - nrf54lv10dk/nrf54lv10a/cpuapp


### PR DESCRIPTION
Typo.